### PR TITLE
Logify

### DIFF
--- a/Simulation/event_logger.py
+++ b/Simulation/event_logger.py
@@ -100,7 +100,7 @@ class GameLogger:
             "is_whisper": is_whisper
         })
     
-    def log_agent_action(self, agent: str, action_type: str, payload: Dict[str, Any], turn: str):
+    def log_agent_action(self, agent: str | Dict, action_type: str, payload: Dict[str, Any], turn: str):
         """Log an agent action (tool call, interaction, etc.)."""
         self.agent_actions_logger.info({
             "timestamp": self._get_timestamp(),
@@ -110,7 +110,7 @@ class GameLogger:
             "payload": payload
         })
     
-    def log_agent_reasoning(self, agent: str, thinking_process: str, turn: str, completion: str = None):
+    def log_agent_reasoning(self, agent: str | Dict, thinking_process: str, turn: str, completion: str = None):
         """Log an agent's thinking process."""
         self.agent_reasoning_logger.info({
             "timestamp": self._get_timestamp(),
@@ -122,7 +122,7 @@ class GameLogger:
             }
         })
     
-    def log_inference_trace(self, event_type: str, agent: str, payload: Dict[str, Any]):
+    def log_inference_trace(self, event_type: str, agent: str | Dict, payload: Dict[str, Any]):
         """Log inference engine performance and debugging info."""
         self.inference_trace_logger.info({
             "timestamp": self._get_timestamp(),
@@ -131,12 +131,13 @@ class GameLogger:
             "payload": payload
         })
     
-    def log_research_metrics(self, agent_name: str, metrics: Dict[str, Any]):
+    def log_research_metrics(self, player_name: str, metrics: Dict[str, Any], agent: str | dict):
         """Log per-agent research metrics."""
         self.research_metrics_logger.info({
             "timestamp": self._get_timestamp(),
             "game_id": self.game_id,
-            "agent_name": agent_name,
+            "player_name": player_name,
+            "agent": agent,
             "metrics": metrics
         })
     
@@ -199,7 +200,7 @@ class GameLogger:
             "duration_days": duration_days
         }, "Game End")
     
-    def log_tool_call(self, agent: str, tool_name: str, arguments: str, result: str, turn: str):
+    def log_tool_call(self, agent: str | Dict, tool_name: str, arguments: str, result: str, turn: str):
         """Log a tool call."""
         self.log_agent_action(agent, "TOOL_CALL", {
             "tool_name": tool_name,
@@ -207,14 +208,14 @@ class GameLogger:
             "result": result
         }, turn)
     
-    def log_interaction(self, agent: str, interaction_type: str, target: str, turn: str):
+    def log_interaction(self, agent: str | Dict, interaction_type: str, target: str, turn: str):
         """Log an interaction (speak, vote, etc.)."""
         self.log_agent_action(agent, "INTERACTION", {
             "interaction_type": interaction_type,
             "target": target
         }, turn)
     
-    def log_sft_sample(self, sample_id: str, agent: str, model_id: str, prompt: List[Dict], completion: str, metadata: Dict[str, Any]):
+    def log_sft_sample(self, sample_id: str, agent: str | Dict, model_id: str, prompt: List[Dict], completion: str, metadata: Dict[str, Any]):
         """Log an SFT training sample with prompt/completion pairs."""
         self.sft_samples_logger.info({
             "timestamp": self._get_timestamp(),
@@ -226,7 +227,7 @@ class GameLogger:
             "metadata": metadata
         })
     
-    def log_inference_complete(self, agent: str, latency_ms: int, prompt_tokens: int, output_tokens: int):
+    def log_inference_complete(self, agent: str | Dict, latency_ms: int, prompt_tokens: int, output_tokens: int):
         """Log inference completion with performance metrics."""
         self.log_inference_trace("INFERENCE_COMPLETE", agent, {
             "latency_ms": latency_ms,
@@ -234,10 +235,10 @@ class GameLogger:
             "output_tokens": output_tokens
         })
     
-    def finalize_player_metrics(self, player):
-        """Log final research metrics for a player."""
+    def finalize_player_metrics(self, player, agent):
+        """Log final research metrics for a player, linked with agent info."""
         if hasattr(player, 'research_metrics'):
-            self.log_research_metrics(player.name, player.research_metrics)
+            self.log_research_metrics(player.name, player.research_metrics, agent)
     
     def close(self):
         """Close all loggers."""

--- a/Simulation/event_logger.py
+++ b/Simulation/event_logger.py
@@ -215,13 +215,13 @@ class GameLogger:
             "target": target
         }, turn)
     
-    def log_sft_sample(self, sample_id: str, agent: str | Dict, model_id: str, prompt: List[Dict], completion: str, metadata: Dict[str, Any]):
+    def log_sft_sample(self, sample_id: str, player_name: str, agent: str | Dict, prompt: List[Dict], completion: str, metadata: Dict[str, Any]):
         """Log an SFT training sample with prompt/completion pairs."""
         self.sft_samples_logger.info({
             "timestamp": self._get_timestamp(),
             "sample_id": sample_id,
+            "player_name": player_name,
             "agent": agent,
-            "model_id": model_id,
             "prompt": prompt,
             "completion": completion,
             "metadata": metadata

--- a/runner/match_runner.py
+++ b/runner/match_runner.py
@@ -36,7 +36,7 @@ from Simulation import interaction_handler as ih
 
 from inference.tool_router import apply_first_tool_call
 
-from runner.lobby_loader import load_lobby, LobbyConfig
+from runner.lobby_loader import load_lobby, LobbyConfig, AgentSpec
 
 from Simulation.token_budget import TokenBudgetManager
 
@@ -63,10 +63,10 @@ def _model_family(model_name: str) -> str | None:
     return None
 
 class AgentContext:
-    def __init__(self, player: Player, model_name: str, lane_url: str):
+    def __init__(self, player: Player, agent: AgentSpec, lane_url: str):
         self.player = player
-        self.model = model_name
-        self.client = InferenceClient(lane_url, model_name)
+        self.agent = agent
+        self.client = InferenceClient(lane_url, agent.model)
         self.chat_history: List[Dict[str, str]] = []
         self.pending_observation: str | None = None
 
@@ -97,10 +97,10 @@ class MatchRunner:
 
         # Register agents with the engine and create contexts
         self.agents: Dict[str, AgentContext] = {}
-        for spec in self.lobby.agents:
-            lane = self.engine.register_agent(spec.id, spec.model)
-            ctx = AgentContext(self._player_by_name(spec.id), spec.model, lane[1])
-            self.agents[spec.id] = ctx
+        for agent_spec in self.lobby.agents:
+            lane = self.engine.register_agent(agent_spec.id, agent_spec.model)
+            ctx = AgentContext(self._player_by_name(agent_spec.id), agent_spec, lane[1])
+            self.agents[agent_spec.id] = ctx
 
         # Token budget manager
         self.budget = TokenBudgetManager.from_yaml("configs/environment_limits.yaml")

--- a/runner/match_runner.py
+++ b/runner/match_runner.py
@@ -68,7 +68,7 @@ class AgentContext:
     def __init__(self, player: Player, agent: AgentSpec | str, lane_url: str):
         self.player = player
         self.agent = agent
-        self.client = InferenceClient(lane_url, agent.model)
+        self.client = InferenceClient(lane_url, agent.model if isinstance(agent, AgentSpec) else  agent)
         self.chat_history: List[Dict[str, str]] = []
         self.pending_observation: str | None = None
 


### PR DESCRIPTION
It may be best to have the agent field in the logging functions either be string or dict (For testing purposes in test_comprehensive_match_runner.py).

The type of AgentContext.agent in MatchRunner was changed to the type AgentSpec. This way whenever we want to log agent info in MatchRunner, we can set agent equal to ctx.agent.id or asdict(ctx.agent), the later will return a dict containing model, quantization, misaligned, etc

This can be rejected/revised if this isn't viable or more changes are needed.